### PR TITLE
Add tagging method for new authors

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -14,13 +14,24 @@ class AuthorsController < ApplicationController
   end
 
   def create
+    @author = Author.new( author_params )
+    @tags = Author.tagging(@author.bio)
+
+    if @author.save
+      @tags.split( ", " ).each do |tag_name|
+        if tag = Tag.find_by( name: tag_name )
+          AuthorTagging.create( author: @author, tag: tag )
+        end
+      end
+      redirect_to authors_path
+    else
+      render 'new'
+    end
   end
-
-
 
   private
 
     def author_params
-      params.require( :author ).permit( :name, :bio)
+      params.require( :author ).permit( :name, :bio )
     end
 end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,5 +1,10 @@
 class Author < ActiveRecord::Base
-  has_many :taggings
-  has_many :tags, through: :taggings
+  has_many :author_taggings
+  has_many :tags, through: :author_taggings
 
+  def self.tagging(text)
+    text_array = text.scan(/\w+/).map(&:downcase)
+    tags_array = Tag.pluck(:name)
+    tags_array & text_array
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,4 @@
 class Tag < ActiveRecord::Base
-  has_many :taggings
-  has_many :authors, through: :taggings
+  has_many :authors_taggings
+  has_many :authors, through: :author_taggings
 end

--- a/app/views/authors/_form.html.erb
+++ b/app/views/authors/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_for @author do |f| %>
+
+  <ul class="field_with_errors">
+    <% @author.errors.full_messages.each do |msg| %>
+      <li class="field_with_errors"><%= msg %></li>
+    <% end %>
+  </ul>
+
+    <div class="form-group">
+       <%= f.label :name %>
+       <%= f.text_field :name, class: "form-control" %>
+    </div>
+
+    <div class="form-group">
+       <%= f.label :bio %>
+       <%= f.text_area :bio, class: "form-control", rows: 10  %>
+    </div>
+
+    <%= f.submit (@author.new_record? ? "Create" : "Update"),
+                  class: "form-control btn-primary" %>
+
+<% end %>

--- a/app/views/authors/new.html.erb
+++ b/app/views/authors/new.html.erb
@@ -1,0 +1,3 @@
+<h1>New Author</h1>
+
+<%= render "form" %>

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -1,0 +1,13 @@
+<h4>
+  <%= @author.name %>
+  <%= link_to "Delete", author_path( @author ),
+      method: :delete,
+      data: { confirm: "Are you sure?" },
+      class: "btn btn-default" %>
+ <%= link_to "Edit", edit_author_path( @author ), class: "btn btn-default" %>
+</h4>
+<%= simple_format @author.bio %>
+
+<%= @author.tags.each do |tag| %>
+  <div class="chip tags z-depth-2"><%= tag.name %></div>
+<% end %>


### PR DESCRIPTION
When creating new author. the new author gets saved in the database
and the bio gets scanned for keywords which saves the result in the join_table author_tagging
